### PR TITLE
add wp_emmet_disable_flag filter.

### DIFF
--- a/WP/Emmet.php
+++ b/WP/Emmet.php
@@ -89,7 +89,7 @@ class WP_Emmet {
 	 * Register hooks
 	 */
 	public function registerHooks() {
-		if (!$this->isInScope()) {
+		if (!$this->isInScope()||apply_filters('wp_emmet_disable_flag', false)) {
 			return;
 		}
 


### PR DESCRIPTION
The filter which can set up a place to make WP-Eemmet invalid from other than a option page was added. 
For example, since goods are managed with the value of $post->post_mime_type in the case of plug-in called Welcart e-Commerce, WP-Emmet cannot be repealed only by setup from a option page. 
In such a case, this filter is used. 

```
// functions.php
add_filter('wp_emmet_disable_flag', function($flag) {
  if( is_admin() && preg_match('/usces_item(edit|new)/', $_GET['page']) ) $flag = true;
  return $flag;
});
```
